### PR TITLE
Fix OTAA.

### DIFF
--- a/src/Sodaq_RN2483.cpp
+++ b/src/Sodaq_RN2483.cpp
@@ -233,7 +233,7 @@ bool Sodaq_RN2483::joinNetwork(const char* type)
     this->loraStream->print(type);
     this->loraStream->print(CRLF);
 
-    return expectOK() && expectString(STR_ACCEPTED);
+    return expectOK() && expectString(STR_ACCEPTED, 10000);
 }
 
 // Sends the given mac command together with the given paramValue


### PR DESCRIPTION
This fixes OTAA activation.

Without this timeout, the `expectString` function returns false before the RN2483 has the time to communicate the OTAA result back.
