### PR TITLE
added sleep(msec) method

### DIFF
--- a/src/Sodaq_RN2483.cpp
+++ b/src/Sodaq_RN2483.cpp
@@ -412,7 +412,7 @@ uint8_t Sodaq_RN2483::onMacRX()
 }
 // Set the RN2483 to sleep for n msec
 //
-void Sodaq_RN2483::sleep(uint16_t msec) {
+void Sodaq_RN2483::sleep(uint32_t msec) {
     debugPrintLn("[sleep] ");
     this->loraStream->print("sys sleep ");
     this->loraStream->print(msec);

--- a/src/Sodaq_RN2483.cpp
+++ b/src/Sodaq_RN2483.cpp
@@ -410,6 +410,16 @@ uint8_t Sodaq_RN2483::onMacRX()
     this->packetReceived = true; // enable receive() again
     return NoError;
 }
+// Set the RN2483 to sleep for n msec
+//
+void Sodaq_RN2483::sleep(uint16_t msec) {
+    debugPrintLn("[sleep] ");
+    this->loraStream->print("sys sleep ");
+    this->loraStream->print(msec);
+    this->loraStream->print(CRLF);
+
+    //does NOT await OK
+}
 
 #ifdef DEBUG
 // Provides a quick test of several methods as a pseudo-unit test.

--- a/src/Sodaq_RN2483.h
+++ b/src/Sodaq_RN2483.h
@@ -90,6 +90,9 @@ public:
 
     // Sets the optional "Diagnostics and Debug" stream.
     void setDiag(Stream& stream) { diagStream = &stream; };
+    
+    // Send chip to sleep for n msec
+    void sleep(uint16_t msec);
 
     // Sends the given payload without acknowledgement.
     // Returns 0 (NoError) when transmission is successful or one of the MacTransmitErrorCodes otherwise.

--- a/src/Sodaq_RN2483.h
+++ b/src/Sodaq_RN2483.h
@@ -92,7 +92,7 @@ public:
     void setDiag(Stream& stream) { diagStream = &stream; };
     
     // Send chip to sleep for n msec
-    void sleep(uint16_t msec);
+    void sleep(uint32_t msec);
 
     // Sends the given payload without acknowledgement.
     // Returns 0 (NoError) when transmission is successful or one of the MacTransmitErrorCodes otherwise.


### PR DESCRIPTION
Allows you to put the Rn2483 into low power sleep for a given time - without the need to wake up the chip 
