### PR TITLE
Fix signed/unsigned expression comparison compiler warning

### DIFF
--- a/src/Sodaq_RN2483.cpp
+++ b/src/Sodaq_RN2483.cpp
@@ -202,7 +202,7 @@ uint8_t Sodaq_RN2483::getHWEUI(uint8_t* buffer, uint8_t size)
         if (readLn() > 0) {
             debugPrintLn(this->inputBuffer);
             while (outputIndex < size
-                && inputIndex + 1 < this->inputBufferSize
+                && inputIndex + 1u < this->inputBufferSize
                 && this->inputBuffer[inputIndex] != 0
                 && this->inputBuffer[inputIndex + 1] != 0) {
                 buffer[outputIndex] = HEX_PAIR_TO_BYTE(


### PR DESCRIPTION
Very small change just to silence a compiler warning. InputIndex & this->inputBufferSize are unsigned but the constant 1 is signed by default (on some compilers?)