### PR TITLE
Expect ok after reset

### DIFF
--- a/src/Sodaq_RN2483.cpp
+++ b/src/Sodaq_RN2483.cpp
@@ -304,6 +304,8 @@ bool Sodaq_RN2483::resetDevice()
 
     this->loraStream->print(STR_CMD_RESET);
     this->loraStream->print(CRLF);
+    
+    expectOK();
 
     if (expectString(STR_DEVICE_TYPE_RN)) {
         if (strstr(this->inputBuffer, STR_DEVICE_TYPE_RN2483) != NULL) {


### PR DESCRIPTION
Without this, the lib is forever waiting for an `RN`, but only ever getting an `ok`:

```
[initABP]
[init]
[sleep]
[wakeUp]
[resetDevice]
[expectString] expecting RN.(ok)
```

See details here:
http://forum.sodaq.com/t/using-sodaq-rn2483-with-sodaq-one/721

Board used is a SODAQ ONE (Kickstarter) 2903 with firmware update from Microchip: `RN2903AU 0.9.7rc7 Aug 11 2016`.
