### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,38 +5,38 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-Sodaq_RN2483			KEYWORD1
+Sodaq_RN2483	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-getDefaultBaudRate		KEYWORD2
-initOTA				KEYWORD2
-initABP				KEYWORD2
-setDiag				KEYWORD2
-send				KEYWORD2
-sendReqAck			KEYWORD2
-receive 			KEYWORD2
-setInputBufferSize 		KEYWORD2
-setReceivedPayloadBufferSize 	KEYWORD2
+getDefaultBaudRate	KEYWORD2
+initOTA	KEYWORD2
+initABP	KEYWORD2
+setDiag	KEYWORD2
+send	KEYWORD2
+sendReqAck	KEYWORD2
+receive	KEYWORD2
+setInputBufferSize	KEYWORD2
+setReceivedPayloadBufferSize	KEYWORD2
 
 #######################################
 # Instances (KEYWORD3)
 #######################################
 
-LoRaBee				KEYWORD3
+LoRaBee	KEYWORD3
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-NoError 			LITERAL1
-NoResponse			LITERAL1
-Timeout				LITERAL1
-TransmissionFailure		LITERAL1
-InternalError			LITERAL1
-Busy				LITERAL1
-NetworkFatalError		LITERAL1
-NotConnected			LITERAL1
-NoAcknowledgment		LITERAL1
+NoError	LITERAL1
+NoResponse	LITERAL1
+Timeout	LITERAL1
+TransmissionFailure	LITERAL1
+InternalError	LITERAL1
+Busy	LITERAL1
+NetworkFatalError	LITERAL1
+NotConnected	LITERAL1
+NoAcknowledgment	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords