### PR TITLE
Added support for getting radio parameters from RN2483

### DIFF
--- a/src/Sodaq_RN2483.cpp
+++ b/src/Sodaq_RN2483.cpp
@@ -757,6 +757,33 @@ void Sodaq_RN2483::getMacParam(const char* paramName, char* buffer, uint8_t size
     debugPrintLn();
 }
 
+// Get radio commands. 
+void Sodaq_RN2483::getRadioParam(const char *paramName, char *buffer, uint8_t size)
+{
+    print(STR_RADIO_GET);
+    println(paramName);
+
+    unsigned long start = millis();
+
+    while (millis() - start < DEFAULT_TIMEOUT) {
+        sodaq_wdt_reset();
+        debugPrint('.');
+
+        if (readLn() > 0) {
+            debugPrint("--> \"");
+            debugPrint(this->_inputBuffer);
+            debugPrint("\"");
+
+            strncpy(buffer, this->_inputBuffer, size);
+
+            break;
+        }
+    }
+
+    debugPrintLn();
+}
+
+
 // Sends the given mac command together with the given paramValue
 // to the device and awaits for the response.
 // Returns true on success.

--- a/src/Sodaq_RN2483.cpp
+++ b/src/Sodaq_RN2483.cpp
@@ -418,11 +418,38 @@ void Sodaq_RN2483::writeProlog()
     }
 }
 
+
+// and false on any other reponse. 
+boolean Sodaq_RN2483::readResult()
+{   
+    unsigned long start = millis();
+
+    while (millis() - start < DEFAULT_TIMEOUT) {
+        sodaq_wdt_reset();
+        debugPrint('.');
+
+        if (readLn() > 0) {
+            debugPrint("--> \"");
+            debugPrint(this->_inputBuffer);
+            debugPrint("\"");
+
+            return true;
+        }
+    } 
+    return false;
+}
+
+
+
 // Write a byte, as binary data
 size_t Sodaq_RN2483::writeByte(uint8_t value)
 {
     return this->_loraStream->write(value);
 }
+
+
+
+
 
 size_t Sodaq_RN2483::print(const String& buffer)
 {
@@ -737,21 +764,9 @@ void Sodaq_RN2483::getMacParam(const char* paramName, char* buffer, uint8_t size
     print(STR_CMD_GET);
     println(paramName);
 
-    unsigned long start = millis();
-
-    while (millis() - start < DEFAULT_TIMEOUT) {
-        sodaq_wdt_reset();
-        debugPrint('.');
-
-        if (readLn() > 0) {
-            debugPrint("--> \"");
-            debugPrint(this->_inputBuffer);
-            debugPrint("\"");
-
-            strncpy(buffer, this->_inputBuffer, size);
-
-            break;
-        }
+    if (readResult())
+    {
+        strncpy(buffer, this->_inputBuffer, size);
     }
 
     debugPrintLn();
@@ -763,24 +778,58 @@ void Sodaq_RN2483::getRadioParam(const char *paramName, char *buffer, uint8_t si
     print(STR_RADIO_GET);
     println(paramName);
 
-    unsigned long start = millis();
-
-    while (millis() - start < DEFAULT_TIMEOUT) {
-        sodaq_wdt_reset();
-        debugPrint('.');
-
-        if (readLn() > 0) {
-            debugPrint("--> \"");
-            debugPrint(this->_inputBuffer);
-            debugPrint("\"");
-
-            strncpy(buffer, this->_inputBuffer, size);
-
-            break;
-        }
+    if (readResult())
+    {
+        strncpy(buffer, this->_inputBuffer, size);
     }
 
     debugPrintLn();
+}
+
+// Radio Signal Strength Indication. 
+int8_t Sodaq_RN2483::getRSSI()
+{
+    uint8_t value = 127;    // Error condition
+    println(STR_RADIO_RSSI);
+
+    if (readResult())
+    {
+        value = atoi(_inputBuffer);        
+    }
+
+    debugPrintLn();
+    return value;
+}
+
+
+// Radio Signal Strength Indication. 
+int8_t Sodaq_RN2483::getSNR()
+{
+    uint8_t value = -128;    // Error condition
+    println(STR_RADIO_SNR);
+
+    if (readResult())
+    {
+        value = atoi(_inputBuffer);        
+    }
+
+    debugPrintLn();
+    return value;
+}
+
+// Radio Signal Strength Indication. 
+int8_t Sodaq_RN2483::getPowerLevel()
+{
+    uint8_t value = -128;    // Error condition
+    println(STR_RADIO_PWR);
+
+    if (readResult())
+    {
+        value = atoi(_inputBuffer);            
+    }
+
+    debugPrintLn();
+    return value;
 }
 
 

--- a/src/Sodaq_RN2483.h
+++ b/src/Sodaq_RN2483.h
@@ -161,6 +161,9 @@ class Sodaq_RN2483
     // Returns mac parameter.
     void getMacParam(const char* paramName, char* buffer, uint8_t size);
 
+    // Return radio parameter.
+    void getRadioParam(const char *paramName, char *buffer, uint8_t size);
+
     // Sends the command together with the given paramValue (optional)
     // to the device and awaits for the response.
     // Returns true on success.

--- a/src/Sodaq_RN2483.h
+++ b/src/Sodaq_RN2483.h
@@ -164,6 +164,15 @@ class Sodaq_RN2483
     // Return radio parameter.
     void getRadioParam(const char *paramName, char *buffer, uint8_t size);
 
+    // Return the RSSI Radio Signal Strength Indication (dBm?)
+    int8_t getRSSI();
+
+    // Get the signal to noise ratio
+    int8_t getSNR();
+
+    // Reports the transmitter output power from -3..15.
+    int8_t getPowerLevel();
+
     // Sends the command together with the given paramValue (optional)
     // to the device and awaits for the response.
     // Returns true on success.
@@ -253,6 +262,10 @@ class Sodaq_RN2483
 
     // (optional) callback to call when a reply is received
     ReceiveCallback _receiveCallback;
+
+    // Get result this function returns true if the buffer contains a valid entry
+    // and false on any other reponse. 
+    boolean readResult();
 
     // Enables hardware-resetting the module.
     void enableHardwareReset(uint8_t resetPin) { this->_resetPin = resetPin; };

--- a/src/Sodaq_RN2483_internal.h
+++ b/src/Sodaq_RN2483_internal.h
@@ -59,6 +59,9 @@
 #define STR_DATARATE "dr "
 
 #define STR_RADIO_GET "radio get "
+#define STR_RADIO_RSSI "radio get rssi"
+#define STR_RADIO_PWR "radio get pwr"
+#define STR_RADIO_SNR "radio get snr"
 
 #define STR_CMD_JOIN "mac join "
 #define STR_OTAA "otaa"

--- a/src/Sodaq_RN2483_internal.h
+++ b/src/Sodaq_RN2483_internal.h
@@ -58,6 +58,8 @@
 #define STR_PWR_IDX "pwridx "
 #define STR_DATARATE "dr "
 
+#define STR_RADIO_GET "radio get "
+
 #define STR_CMD_JOIN "mac join "
 #define STR_OTAA "otaa"
 #define STR_ABP "abp"


### PR DESCRIPTION
This patch adds support for getting the radio parameters from the RN2483.
For instance the RSSI, pwr, and snr parameters. 
It works the same as the getMacParam call. 